### PR TITLE
feat [#56] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/org/cotato/tlinkserver/api/controller/UserController.java
+++ b/src/main/java/org/cotato/tlinkserver/api/controller/UserController.java
@@ -1,0 +1,29 @@
+package org.cotato.tlinkserver.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.tlinkserver.annotation.Permission;
+import org.cotato.tlinkserver.annotation.UserId;
+import org.cotato.tlinkserver.api.facade.UserFacade;
+import org.cotato.tlinkserver.domain.user.constant.Role;
+import org.cotato.tlinkserver.global.common.BaseResponse;
+import org.cotato.tlinkserver.global.message.SuccessMessage;
+import org.cotato.tlinkserver.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final UserFacade userFacade;
+
+    @Permission(role = {Role.STUDENT, Role.PARENT, Role.TEACHER})
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<?>> deleteAccount(@UserId Long userId) {
+        userFacade.deleteAccount(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+}

--- a/src/main/java/org/cotato/tlinkserver/api/facade/UserFacade.java
+++ b/src/main/java/org/cotato/tlinkserver/api/facade/UserFacade.java
@@ -1,0 +1,30 @@
+package org.cotato.tlinkserver.api.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.tlinkserver.annotation.Facade;
+import org.cotato.tlinkserver.auth.ReissueService;
+import org.cotato.tlinkserver.domain.user.application.UserService;
+import org.cotato.tlinkserver.global.exception.NotFoundException;
+import org.cotato.tlinkserver.global.message.ErrorMessage;
+import org.springframework.transaction.annotation.Transactional;
+
+@Facade
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+    private final ReissueService reissueService;
+
+    @Transactional
+    public void deleteAccount(long userId) {
+        validateExistUser(userId);
+        userService.deleteUserById(userId);
+        reissueService.deleteAllByUserId(userId);
+    }
+
+    private void validateExistUser(long userId) {
+        if (!userService.existUserById(userId)) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/org/cotato/tlinkserver/auth/ReissueService.java
+++ b/src/main/java/org/cotato/tlinkserver/auth/ReissueService.java
@@ -35,11 +35,21 @@ public class ReissueService {
                 RefreshToken.of(newRefreshToken, Long.parseLong(userId))
         );
 
-        refreshTokenRepository.deleteAllByUserIdAndRefreshToken(
+        deleteAllByUserIdAndRefreshToken(
                 Long.parseLong(userId), token.getRefreshToken()
         );
 
         return new Token(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void deleteAllByUserId(long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+    }
+
+    @Transactional
+    public void deleteAllByUserIdAndRefreshToken(long userId, String refreshToken) {
+        refreshTokenRepository.deleteAllByUserIdAndRefreshToken(userId, refreshToken);
     }
 
     private RefreshToken getValidRefreshToken(String refreshToken) {

--- a/src/main/java/org/cotato/tlinkserver/domain/user/application/UserService.java
+++ b/src/main/java/org/cotato/tlinkserver/domain/user/application/UserService.java
@@ -23,4 +23,9 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(UnauthorizedException::wrong);
     }
+
+    @Transactional
+    public void deleteUserById(long userId) {
+        userRepository.deleteById(userId);
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 

## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #56 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 회원 탈퇴 API 구현

## ✨ Description ✨ ##
<!-- 본인이 한 작업을 설명해주세요 -->
<!-- 고민, 개선사항 포함 -->
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/560d2a20-e8ad-4bfa-8337-a039561f7f16" />

회원 탈퇴 시 리프레시 토큰 등 관련된 회원 정보가 모두 삭제되도록 했습니다.
추가로, 온보딩 과정 중 호출될 수 없는 로직이기 때문에 역할 권한도 설정해두었습니다.
