### PR TITLE
fix [#144] 선생님 권한 미반환 해결

### DIFF
--- a/src/main/java/org/cotato/tlinkserver/api/controller/RoomController.java
+++ b/src/main/java/org/cotato/tlinkserver/api/controller/RoomController.java
@@ -115,7 +115,7 @@ public class RoomController {
     @GetMapping("/{roomId}")
     public ResponseEntity<BaseResponse<?>> viewRoomDetail(
             @UserId Long userId,
-            @PathVariable @NotNull Long roomId
+            @PathVariable("roomId") @NotNull Long roomId
     ) {
         RoomDetailDTO roomDetailDTO = roomFacade.getRoomDetail(userId, roomId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, RoomDetailResponse.from(roomDetailDTO));

--- a/src/main/java/org/cotato/tlinkserver/api/facade/RoomFacade.java
+++ b/src/main/java/org/cotato/tlinkserver/api/facade/RoomFacade.java
@@ -109,8 +109,11 @@ public class RoomFacade {
 
         Registration registration = registrationService.getRegistration(room.getId(), user.getRole());
 
-        if (registration.getUser() == null) {
-            registration.setUser(user);
+        if (registration == null) {
+
+            registration = new Registration(user.getRole(),
+                    room.getRegistrations().stream().filter(r -> r.getRole().equals(Role.TEACHER)).findFirst().get()
+                            .getRoomName());
             user.addRegistration(registration);
             return 1;
         } else if (registration.getUser().equals(user)) {

--- a/src/main/java/org/cotato/tlinkserver/domain/room/Registration.java
+++ b/src/main/java/org/cotato/tlinkserver/domain/room/Registration.java
@@ -18,8 +18,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.cotato.tlinkserver.domain.user.User;
 import org.cotato.tlinkserver.domain.user.constant.Role;
-import org.cotato.tlinkserver.global.exception.TLinkException;
-import org.cotato.tlinkserver.global.message.ErrorMessage;
 
 @Entity
 @Table(name = "registrations")
@@ -62,7 +60,7 @@ public class Registration {
             return room.getStudentPermission().isLectureFile();
         }
 
-        throw new TLinkException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        return true;
     }
 
     public boolean getHomeworkPermission() {
@@ -74,7 +72,7 @@ public class Registration {
             return room.getStudentPermission().isHomework();
         }
 
-        throw new TLinkException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        return true;
     }
 
     public boolean getGradeStatisticPermission() {
@@ -86,7 +84,7 @@ public class Registration {
             return room.getStudentPermission().isGradeStatistic();
         }
 
-        throw new TLinkException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        return true;
     }
 
     public boolean getCounselingLogPermission() {
@@ -98,7 +96,7 @@ public class Registration {
             return room.getStudentPermission().isCounselingLog();
         }
 
-        throw new TLinkException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        return true;
     }
 
     public boolean getDepositPermission() {
@@ -110,6 +108,6 @@ public class Registration {
             return room.getStudentPermission().isDeposit();
         }
 
-        throw new TLinkException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        return true;
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 

## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #144 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 선생님일 때, 권한을 true로 반환

## ✨ Description ✨
<!-- 본인이 한 작업을 설명해주세요 -->
<!-- 고민, 개선사항 포함 -->
학생이나 학부모가 과외방 상세 조회를 할 때, 권한에 따라 사용할 수 있는 기능을 제한합니다.
선생님은 모든 기능을 사용가능한데, 프론트엔드에서 같은 코드를 사용하고 있어 true를 반환하도록 했습니다.